### PR TITLE
removed-geocint-osm-part-on-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ tested by other team members, and will automatically produce new artifacts once 
 
 Geocint consists of 3 different parts:
 - [geocint-runner](https://github.com/konturio/geocint-runner) - a core part of the pipeline, includes utilities and initial Makefile
-- [geocint-openstreetmap](https://github.com/konturio/geocint-openstreetmap) - a chain of targets for downloading, updating and uploading 
-to database OpenStreetMap planet dump
 - [geocint-private] any repository that contains your additional functionality
 
 ![image](https://user-images.githubusercontent.com/810638/209176952-826382d6-35bc-469a-adaa-ef265cfdd9ac.png)


### PR DESCRIPTION
This is for testing purposes - removed geocint-osm title part from readme